### PR TITLE
Tidied up your addLoader usage

### DIFF
--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -52,13 +52,11 @@ end
 
 -- Vanilla Loaders HD (vanilla-loaders-hd) integration
 if vanillaHD then
-    -- This part acn be more compact, but this is ok.
-    local nuclear_loader_next_tier = nil
-    if mods['PlutoniumEnergy'] then nuclear_loader_next_tier = 'plutonium-loader' end
-    -- Nuclear [empowered] loader
-    vanillaHD.addLoader('nuclear-loader', {r=0,g=255,b=0}, 'nuclear-transport-belt', 'nuclear-logistics', 'express-loader')
-    if mods['PlutoniumEnergy'] then
-        -- Plutonium loader
-        vanillaHD.addLoader('plutonium-loader', {r=26,g=230,b=179}, 'plutonium-transport-belt', 'plutonium-logistics', 'nuclear-loader')
+    -- Create nuclear loader
+    vanillaHD.addLoader("nuclear-loader", {r=0,g=255,b=0}, "nuclear-transport-belt", "nuclear-logistics", "express-loader")
+
+    -- If PlutoniumEnergy is present, create plutonium loader with nuclear loader as the previous tier
+    if mods ["PlutoniumEnergy"] then
+        vanillaHD.addLoader("plutonium-loader", {r=26,g=230,b=179}, "plutonium-transport-belt", "plutonium-logistics", "nuclear-loader")
     end
 end


### PR DESCRIPTION
Next_tier it turns out doesn't need to be specified, so long as you create your loaders in order. The function goes back and connects the previous tier to the current one.

Only need to use next_tier when inserting in between tiers. :D